### PR TITLE
Jlc/fix env vars

### DIFF
--- a/webpack.prod.config.js
+++ b/webpack.prod.config.js
@@ -1,0 +1,19 @@
+const fs = require('fs');
+const dotenv = require('dotenv');
+const { createConfig } = require('@edx/frontend-build');
+
+const config = createConfig('webpack-prod');
+
+// The configuration is generated using the createConfig method from the frontend-build library,
+// this method preloads multiple files to generate the resulting configuration, including webpack.common.config.js,
+// https://github.com/nelc/frontend-build/blob/open-release/palm.nelp/config/webpack.common.config.js,
+// which includes ParagonWebpackPlugin. This plugin, in turn, retrieves its configuration from the .env.development file
+// https://github.com/nelc/frontend-build/blob/open-release/palm.nelp/lib/plugins/paragon-webpack-plugin/ParagonWebpackPlugin.js#L20-L22
+// Therefore, regardless of the configuration type, the plugin always utilizes data from .env.development.
+// The following code overrides this behavior in order to use the .env file.
+const envConfig = dotenv.parse(fs.readFileSync('.env'));
+Object.keys(envConfig).forEach(k => {
+  process.env[k] = envConfig[k];
+});
+
+module.exports = config;


### PR DESCRIPTION
### Description

this is like a cherrypick of this pr in learning.
https://github.com/nelc/frontend-app-learning/pull/27/files
This is an error generated by the load of paragonTheme plugin.

This also fix the sitename by default.
Meanwhile, there is no runtime configuration for these items, the favicon, and head-name aka sitename wouldn't be tenant-aware and runtime.
There is a PR opened in the community to fix these items.
https://github.com/openedx/frontend-app-discussions/pull/668
#### How Has This Been Tested?

Check the built process is using the new file, and check the variables are using the defined in `.env`.
![image](https://github.com/nelc/frontend-app-discussions/assets/51926076/ab5fe49c-85ad-44d1-b025-cd1bfd47f143)

#### Screenshots/sandbox (optional):
Include a link to the sandbox for design changes or screenshot for before and after. **Remove this section if it's not applicable.**

|Before|After|
|--------------------------|----------------------------|
|![before_env_discussions](https://github.com/nelc/frontend-app-discussions/assets/51926076/c329be74-a988-43a7-bfe8-65510675b4b9)|![after_env_discussions](https://github.com/nelc/frontend-app-discussions/assets/51926076/eef18ce2-4266-428e-969d-577b50277999)|

#### Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Sandbox, if applicable.
* [ ] Is there adequate test coverage for your changes?

#### Post-merge Checklist

* [ ] Deploy the changes to prod after verifying on stage or ask **@openedx/edx-infinity** to do it. 
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.