### PR TITLE
feat: add custom nelc dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "version": "0.1.0",
       "license": "AGPL-3.0",
       "dependencies": {
-        "@edx/brand": "npm:@openedx/brand-openedx@^1.2.2",
+        "@edx/brand": "github:nelc/brand-openedx#open-release/redwood.nelp",
         "@edx/frontend-component-header": "npm:@edunext/frontend-component-header@5.0.2-alpha.1",
-        "@edx/frontend-platform": "npm:@edunext/frontend-platform@7.1.2-alpha.1",
+        "@edx/frontend-platform": "npm:@edunext/frontend-platform@^7.1.2-alpha-nelc.1",
         "@edx/openedx-atlas": "^0.6.0",
         "@openedx/frontend-slot-footer": "^1.0.2",
         "@openedx/paragon": "23.0.0-alpha.1",
@@ -2115,9 +2115,9 @@
     },
     "node_modules/@edx/brand": {
       "name": "@openedx/brand-openedx",
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@openedx/brand-openedx/-/brand-openedx-1.2.3.tgz",
-      "integrity": "sha512-Dn9CtpC8fovh++Xi4NF5NJoeR9yU2yXZnV9IujxIyGd/dn0Phq5t6dzJVfupwq09mpDnzJv7egA8Znz/3ljO+w=="
+      "version": "1.0.0-semantically-released",
+      "resolved": "git+ssh://git@github.com/nelc/brand-openedx.git#26a12963086817ccb9cf2d4bcda3bcc1bd944236",
+      "license": "GPL-3.0-or-later"
     },
     "node_modules/@edx/browserslist-config": {
       "version": "1.2.0",
@@ -3582,9 +3582,9 @@
     },
     "node_modules/@edx/frontend-platform": {
       "name": "@edunext/frontend-platform",
-      "version": "7.1.2-alpha.1",
-      "resolved": "https://registry.npmjs.org/@edunext/frontend-platform/-/frontend-platform-7.1.2-alpha.1.tgz",
-      "integrity": "sha512-bsK7DxIdges9Ih57QIravKWov2oqMse0TSA/wYGkndtHRiwmkI2BK8mEi90PuRSRj0jymFe1FY9D++WI+9zakg==",
+      "version": "7.1.2-alpha-nelc.1",
+      "resolved": "https://registry.npmjs.org/@edunext/frontend-platform/-/frontend-platform-7.1.2-alpha-nelc.1.tgz",
+      "integrity": "sha512-UearJi4Mh5a1twdLxVCPGk/jnRcCAyKk2aPWQEU6Vw/VYmugMBcTAKH0pvxqdClN1qiWw5Jhi0ygiF8VTNgs3g==",
       "dependencies": {
         "@cospired/i18n-iso-languages": "4.2.0",
         "@formatjs/intl-pluralrules": "4.3.3",
@@ -7105,6 +7105,12 @@
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
       }
+    },
+    "node_modules/@openedx/frontend-slot-footer/node_modules/@edx/brand": {
+      "name": "@openedx/brand-openedx",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@openedx/brand-openedx/-/brand-openedx-1.2.3.tgz",
+      "integrity": "sha512-Dn9CtpC8fovh++Xi4NF5NJoeR9yU2yXZnV9IujxIyGd/dn0Phq5t6dzJVfupwq09mpDnzJv7egA8Znz/3ljO+w=="
     },
     "node_modules/@openedx/frontend-slot-footer/node_modules/@edx/eslint-config": {
       "version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -34,9 +34,9 @@
     "url": "https://github.com/openedx/frontend-app-discussions/issues"
   },
   "dependencies": {
-    "@edx/brand": "npm:@openedx/brand-openedx@^1.2.2",
+    "@edx/brand": "github:nelc/brand-openedx#open-release/redwood.nelp",
     "@edx/frontend-component-header": "npm:@edunext/frontend-component-header@5.0.2-alpha.1",
-    "@edx/frontend-platform": "npm:@edunext/frontend-platform@7.1.2-alpha.1",
+    "@edx/frontend-platform": "npm:@edunext/frontend-platform@^7.1.2-alpha-nelc.1",
     "@edx/openedx-atlas": "^0.6.0",
     "@openedx/frontend-slot-footer": "^1.0.2",
     "@openedx/paragon": "23.0.0-alpha.1",

--- a/src/index.scss
+++ b/src/index.scss
@@ -1,5 +1,7 @@
 @import "~@edx/frontend-component-footer/dist/footer";
 @import "~@edx/frontend-component-header/dist/index";
+@import "@edx/brand/paragon/variables.scss";
+@import "@edx/brand/paragon/overrides.scss";
 
 #post,
 #comment,


### PR DESCRIPTION
### Description

This updates frontend-platform and brand-openedx dependencies and finally set the custom styles [issue](https://edunext.atlassian.net/browse/FUTUREX-972)

#### How to test?
1. Delete node modules folder and run `npm install`
2. Open discussion -> the mfe must load with default color 
3. Add the following setting and check discussion page -> the mfe must load with red color
```
  "CUSTOM_PRIMARY_COLORS": {
    "pgn-color-primary-base": "#AA0000"
  },
```
4. Add the following setting and check discussion page -> the mfe must load with green color
```
  "PARAGON_THEME_URLS": {
    "core": {
        "url": "https://cdn.jsdelivr.net/combine/npm/@edx/paragon@22.0.0-alpha.13/styles/css/themes/light/utility-classes.min.css,npm/@edx/paragon@22.0.0-alpha.13/dist/core.min.css"
    },
    "defaults": {
        "light": "light"
    },
    "variants": {
        "light": {
            "url": "https://css-varsify.s3.amazonaws.com/public/a9959998-0bab-4447-ada5-6819866195f3.css"
        }
    }
  },
```
5. check the typography 

## Result
![image](https://github.com/user-attachments/assets/0448b8b6-2761-434a-a411-ffe614f13abe)


