### PR TITLE
feat: add frontend-essentials translations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,9 +61,10 @@ pull_translations:
 	           translations/frontend-component-footer/src/i18n/messages:frontend-component-footer \
 	           translations/frontend-platform/src/i18n/messages:frontend-platform \
 	           translations/paragon/src/i18n/messages:paragon \
-	           translations/frontend-app-discussions/src/i18n/messages:frontend-app-discussions
+	           translations/frontend-app-discussions/src/i18n/messages:frontend-app-discussions \
+	           translations/frontend-essentials/src/i18n/messages:frontend-essentials
 
-	$(intl_imports) frontend-component-header frontend-component-footer frontend-platform paragon frontend-app-discussions
+	$(intl_imports) frontend-component-header frontend-component-footer frontend-platform paragon frontend-app-discussions frontend-essentials
 # endif
 
 # This target is used by Travis.


### PR DESCRIPTION
### Description
This add the frontend-essentials package to the pull_translation workflow


## Before
![image](https://github.com/user-attachments/assets/1776bc03-e593-4e5a-8017-ceb1d6f6864d)


## After
![image](https://github.com/user-attachments/assets/01c4eea7-a02b-4571-b281-484904a22263)


## Notes
This depends on this [branch](https://github.com/nelc/futurex-translations/tree/and/add_essentials_translations), the revision value from the local variable `ATLAS_OPTIONS` has been change to `and/add_essentials_translations` (temporary)