### PR TITLE
feat: update frontend-component-header to 5.0.2-alpha.1-nelp.12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "AGPL-3.0",
       "dependencies": {
         "@edx/brand": "github:nelc/brand-openedx#open-release/redwood.nelp",
-        "@edx/frontend-component-header": "npm:@edunext/frontend-component-header@5.0.2-alpha.1-nelp.11",
+        "@edx/frontend-component-header": "npm:@edunext/frontend-component-header@5.0.2-alpha.1-nelp.12",
         "@edx/frontend-platform": "npm:@edunext/frontend-platform@^7.1.2-alpha-nelc.1",
         "@edx/openedx-atlas": "^0.6.0",
         "@openedx/frontend-slot-footer": "^1.0.2",
@@ -2114,9 +2114,9 @@
       }
     },
     "node_modules/@edunext/frontend-essentials": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/@edunext/frontend-essentials/-/frontend-essentials-4.6.0.tgz",
-      "integrity": "sha512-FDPxy0tPFPXXbcsck+ojydeV8ho4HN/1iob9Q1+/HA0ribtlD0OimBYBHh4Qot56mcvP3y5SF0nHq3VACoWxpw==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@edunext/frontend-essentials/-/frontend-essentials-4.7.0.tgz",
+      "integrity": "sha512-6p8cDVy3mnHDGpHn1xAyht4Q7kHEpUbASsl1AttICrOjKzJYLWmO0N5DHlEf1GK5aay7DOWD/4piu2S5lWYFsw==",
       "dependencies": {
         "@edx/frontend-platform": "npm:@edunext/frontend-platform@^7.1.2-alpha-nelc.1",
         "@emotion/react": "^11.11.0",
@@ -3611,11 +3611,11 @@
     },
     "node_modules/@edx/frontend-component-header": {
       "name": "@edunext/frontend-component-header",
-      "version": "5.0.2-alpha.1-nelp.11",
-      "resolved": "https://registry.npmjs.org/@edunext/frontend-component-header/-/frontend-component-header-5.0.2-alpha.1-nelp.11.tgz",
-      "integrity": "sha512-THiuBs97chOCAZvqt4cRyxecgsyUcyXkSagyGqZeVZeXktHOT6/dNSxHwK18GhCcFnkjtWrI6qhKMNbMVIHFXA==",
+      "version": "5.0.2-alpha.1-nelp.12",
+      "resolved": "https://registry.npmjs.org/@edunext/frontend-component-header/-/frontend-component-header-5.0.2-alpha.1-nelp.12.tgz",
+      "integrity": "sha512-8KlE17e1ZGJHq2RbebXrGNUi9EPbAw4BAEqfduYTsWZ45K8FlipClA+D4oBdN5DqlNh0PObCcJpG7/3+YbkAjw==",
       "dependencies": {
-        "@edunext/frontend-essentials": "4.6.0",
+        "@edunext/frontend-essentials": "^4.7.0",
         "@fortawesome/fontawesome-svg-core": "6.5.1",
         "@fortawesome/free-brands-svg-icons": "6.5.1",
         "@fortawesome/free-regular-svg-icons": "6.5.1",
@@ -3838,9 +3838,9 @@
       "integrity": "sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg=="
     },
     "node_modules/@emotion/styled": {
-      "version": "11.14.0",
-      "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.0.tgz",
-      "integrity": "sha512-XxfOnXFffatap2IyCeJyNov3kiDQWoR08gPUQxvbL7fxKryGBKUZUkG6Hz48DZwVrJSVh9sJboyV1Ds4OW6SgA==",
+      "version": "11.14.1",
+      "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.1.tgz",
+      "integrity": "sha512-qEEJt42DuToa3gurlH4Qqc1kVpNq8wO8cJtDzU46TjlzWjDlsVyevtYCRijVq3SrHsROS+gVQ8Fnea108GnKzw==",
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -5764,22 +5764,22 @@
       "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A=="
     },
     "node_modules/@mui/core-downloads-tracker": {
-      "version": "5.17.1",
-      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-5.17.1.tgz",
-      "integrity": "sha512-OcZj+cs6EfUD39IoPBOgN61zf1XFVY+imsGoBDwXeSq2UHJZE3N59zzBOVjclck91Ne3e9gudONOeILvHCIhUA==",
+      "version": "5.18.0",
+      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-5.18.0.tgz",
+      "integrity": "sha512-jbhwoQ1AY200PSSOrNXmrFCaSDSJWP7qk6urkTmIirvRXDROkqe+QwcLlUiw/PrREwsIF/vm3/dAXvjlMHF0RA==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mui-org"
       }
     },
     "node_modules/@mui/material": {
-      "version": "5.17.1",
-      "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.17.1.tgz",
-      "integrity": "sha512-2B33kQf+GmPnrvXXweWAx+crbiUEsxCdCN979QDYnlH9ox4pd+0/IBriWLV+l6ORoBF60w39cWjFnJYGFdzXcw==",
+      "version": "5.18.0",
+      "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.18.0.tgz",
+      "integrity": "sha512-bbH/HaJZpFtXGvWg3TsBWG4eyt3gah3E7nCNU8GLyRjVoWcA91Vm/T+sjHfUcwgJSw9iLtucfHBoq+qW/T30aA==",
       "dependencies": {
         "@babel/runtime": "^7.23.9",
-        "@mui/core-downloads-tracker": "^5.17.1",
-        "@mui/system": "^5.17.1",
+        "@mui/core-downloads-tracker": "^5.18.0",
+        "@mui/system": "^5.18.0",
         "@mui/types": "~7.2.15",
         "@mui/utils": "^5.17.1",
         "@popperjs/core": "^2.11.8",
@@ -5817,9 +5817,9 @@
       }
     },
     "node_modules/@mui/material/node_modules/react-is": {
-      "version": "19.1.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.1.0.tgz",
-      "integrity": "sha512-Oe56aUPnkHyyDxxkvqtd7KkdQP5uIUfHxd5XTb3wE9d/kRnZLmKbDB0GWk919tdQ+mxxPtG6EAs6RMT6i1qtHg=="
+      "version": "19.1.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.1.1.tgz",
+      "integrity": "sha512-tr41fA15Vn8p4X9ntI+yCyeGSf1TlYaY5vlTZfQmeLBrFo3psOPX6HhTDnFNL9uj3EhP0KAQ80cugCl4b4BERA=="
     },
     "node_modules/@mui/private-theming": {
       "version": "5.17.1",
@@ -5848,12 +5848,13 @@
       }
     },
     "node_modules/@mui/styled-engine": {
-      "version": "5.16.14",
-      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-5.16.14.tgz",
-      "integrity": "sha512-UAiMPZABZ7p8mUW4akDV6O7N3+4DatStpXMZwPlt+H/dA0lt67qawN021MNND+4QTpjaiMYxbhKZeQcyWCbuKw==",
+      "version": "5.18.0",
+      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-5.18.0.tgz",
+      "integrity": "sha512-BN/vKV/O6uaQh2z5rXV+MBlVrEkwoS/TK75rFQ2mjxA7+NBo8qtTAOA4UaM0XeJfn7kh2wZ+xQw2HAx0u+TiBg==",
       "dependencies": {
         "@babel/runtime": "^7.23.9",
         "@emotion/cache": "^11.13.5",
+        "@emotion/serialize": "^1.3.3",
         "csstype": "^3.1.3",
         "prop-types": "^15.8.1"
       },
@@ -5879,13 +5880,13 @@
       }
     },
     "node_modules/@mui/system": {
-      "version": "5.17.1",
-      "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.17.1.tgz",
-      "integrity": "sha512-aJrmGfQpyF0U4D4xYwA6ueVtQcEMebET43CUmKMP7e7iFh3sMIF3sBR0l8Urb4pqx1CBjHAaWgB0ojpND4Q3Jg==",
+      "version": "5.18.0",
+      "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.18.0.tgz",
+      "integrity": "sha512-ojZGVcRWqWhu557cdO3pWHloIGJdzVtxs3rk0F9L+x55LsUjcMUVkEhiF7E4TMxZoF9MmIHGGs0ZX3FDLAf0Xw==",
       "dependencies": {
         "@babel/runtime": "^7.23.9",
         "@mui/private-theming": "^5.17.1",
-        "@mui/styled-engine": "^5.16.14",
+        "@mui/styled-engine": "^5.18.0",
         "@mui/types": "~7.2.15",
         "@mui/utils": "^5.17.1",
         "clsx": "^2.1.0",
@@ -5960,9 +5961,9 @@
       }
     },
     "node_modules/@mui/utils/node_modules/react-is": {
-      "version": "19.1.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.1.0.tgz",
-      "integrity": "sha512-Oe56aUPnkHyyDxxkvqtd7KkdQP5uIUfHxd5XTb3wE9d/kRnZLmKbDB0GWk919tdQ+mxxPtG6EAs6RMT6i1qtHg=="
+      "version": "19.1.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.1.1.tgz",
+      "integrity": "sha512-tr41fA15Vn8p4X9ntI+yCyeGSf1TlYaY5vlTZfQmeLBrFo3psOPX6HhTDnFNL9uj3EhP0KAQ80cugCl4b4BERA=="
     },
     "node_modules/@newrelic/publish-sourcemap": {
       "version": "5.1.0",
@@ -24504,9 +24505,9 @@
       }
     },
     "node_modules/react-international-phone": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/react-international-phone/-/react-international-phone-4.5.0.tgz",
-      "integrity": "sha512-wjwHv+VfiwM49B5/6El4Z5vZKmf3ILpUeiOCI9X+b0Dq4g5nL8gROcwCdVcTXywxznbDSoxSassBX3i9tPZX6g==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/react-international-phone/-/react-international-phone-4.6.0.tgz",
+      "integrity": "sha512-lzj5fLfACRKeaitggFIHWl6LM69aO2uivJbEVyVBjAe0+kkvZjToduqnK2/dm9Zu+l8XfVjd+Fn1ZAyG/t8XAg==",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@edx/brand": "github:nelc/brand-openedx#open-release/redwood.nelp",
-    "@edx/frontend-component-header": "npm:@edunext/frontend-component-header@5.0.2-alpha.1-nelp.11",
+    "@edx/frontend-component-header": "npm:@edunext/frontend-component-header@5.0.2-alpha.1-nelp.12",
     "@edx/frontend-platform": "npm:@edunext/frontend-platform@^7.1.2-alpha-nelc.1",
     "@edx/openedx-atlas": "^0.6.0",
     "@openedx/frontend-slot-footer": "^1.0.2",


### PR DESCRIPTION
### Description

Update frontend-component-header to 5.0.2-alpha.1-nelp.12 basically that version includes an update of frontend-essentials, the version included is 4.7.0 and the testing instructions are the same as this [pr](https://github.com/nelc/frontend-essentials/pull/70)

### Before
<img width="1498" height="888" alt="image" src="https://github.com/user-attachments/assets/b707e5a7-71ac-4d36-b886-5ad560e7d69f" />


### After
<img width="1505" height="891" alt="image" src="https://github.com/user-attachments/assets/6e2eede2-f370-494d-bf5e-341257327191" />


